### PR TITLE
chore: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/proxy.sh
+++ b/proxy.sh
@@ -2,6 +2,6 @@ docker run --rm --name docker_registry_proxy -d \
        -p 0.0.0.0:3128:3128 \
        -v $(pwd)/docker_mirror_cache:/docker_mirror_cache \
        -v $(pwd)/docker_mirror_certs:/ca \
-       -e REGISTRIES="k8s.gcr.io gcr.io quay.io your.own.registry another.public.registry zjharbor.com" \
+       -e REGISTRIES="registry.k8s.io gcr.io quay.io your.own.registry another.public.registry zjharbor.com" \
        -e AUTH_REGISTRIES="auth.docker.io:dockerhub_username:dockerhub_password your.own.registry:username:password" \
        rpardini/docker-registry-proxy:0.2.4


### PR DESCRIPTION
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.